### PR TITLE
Ultimo horario para atendimentos

### DIFF
--- a/04-iniciando-back-end/src/modules/appointments/services/ListProviderMonthAvailabilityService.ts
+++ b/04-iniciando-back-end/src/modules/appointments/services/ListProviderMonthAvailabilityService.ts
@@ -42,7 +42,7 @@ class ListProviderMonthAvailabilityService {
     );
 
     const availability = eachDayArray.map(day => {
-      const compareDate = new Date(year, month - 1, day, 23, 59, 59);
+      const compareDate = new Date(year, month - 1, day, 17);
 
       const appointmentsInDay = appointments.filter(appointment => {
         return getDate(appointment.date) === day;


### PR DESCRIPTION
Na forma atual se você listar os agendamentos depois das 17h vai lista erroneamente o dia como disponível para agendamentos já que o horário limite e ate as 17h