### PR TITLE
Update config for webpack-dev-server

### DIFF
--- a/02-conceitos-dev/frontend/webpack.config.js
+++ b/02-conceitos-dev/frontend/webpack.config.js
@@ -7,7 +7,11 @@ module.exports = {
     filename: 'bundle.js'
   },
   devServer: {
-    contentBase: path.resolve(__dirname, 'public'),
+    static: {
+      directory: path.resolve(__dirname, 'public'),
+    },
+    compress: true,
+    port: 9000
   },
   module: {
     rules: [


### PR DESCRIPTION
Lendo a descrição da aula me deperei com o problema de versão ao rodar o comando de live reload do webpack.
Adicionei uma nova configuração que funciona na versão nova.
https://webpack.js.org/configuration/dev-server/